### PR TITLE
(Dec 20): Update for new Namecheap URL

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+icontribute.site

--- a/generateCNAME.js
+++ b/generateCNAME.js
@@ -1,2 +1,2 @@
 const fs = require('fs');
-fs.writeFileSync('build/CNAME', 'icontribute.community');
+fs.writeFileSync('build/CNAME', 'icontribute.site');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contrib",
-  "homepage": "https://icontribute.community",
+  "homepage": "https://icontribute.site",
   "version": "0.1.0",
   "private": true,
   "dependencies": {

--- a/src/components/SocialMediaBar/SocialMediaBar.jsx
+++ b/src/components/SocialMediaBar/SocialMediaBar.jsx
@@ -24,7 +24,7 @@ function SocialMediaBar() {
         <img src={tiktok} alt="tiktok" className="SocialMediaBar-Icon" />
       </a>
       <a
-        href="https://www.instagram.com/icontribute.community/"
+        href="https://www.instagram.com/icontribute.site/"
         target="_blank"
         rel="noopener noreferrer"
         className="SocialMediaBar-Link"

--- a/src/components/StickySocials/StickySocials.jsx
+++ b/src/components/StickySocials/StickySocials.jsx
@@ -30,7 +30,7 @@ const StickySocials = () => {
       <a
         target="_blank"
         rel="noopener noreferrer"
-        href="https://www.facebook.com/icontribute.community"
+        href="https://www.facebook.com/icontribute.site"
       >
         <img
           onMouseEnter={() => {
@@ -62,7 +62,7 @@ const StickySocials = () => {
       <a
         target="_blank"
         rel="noopener noreferrer"
-        href="https://www.instagram.com/icontribute.community/"
+        href="https://www.instagram.com/icontribute.site/"
       >
         <img
           onMouseEnter={() => {

--- a/src/screens/PrivacyPolicyScreen.jsx
+++ b/src/screens/PrivacyPolicyScreen.jsx
@@ -22,7 +22,7 @@ const HomeScreen = () => {
           practices in line with privacy laws. iContribute uses modern information and 
           communication technologies to support our activities. Please take a few moments
           to review this privacy policy (herein referred to as the “Privacy Policy”),
-          which applies to our website,<a id="links" href="https://icontribute.community" target="_blank" rel="noopener noreferrer"> https://icontribute.community </a>
+          which applies to our website,<a id="links" href="https://icontribute.site" target="_blank" rel="noopener noreferrer"> https://icontribute.site </a>
           (the “<b>Website</b>”), 
           our mobile app (the “<b>iContribute Mobile App</b>” or the “<b>App</b>”), and related products 
           (collectively, with the Website and the iContribute Mobile App, referred to as
@@ -58,7 +58,7 @@ const HomeScreen = () => {
         <p className="ft1">
           This Privacy Policy is incorporated into and subject to our Terms and 
           Conditions (the “<b>Terms and Conditions</b>”) 
-          <a id="links" href="https://icontribute.community/#/privacy"> (https://icontribute.community/#/privacy)</a>. 
+          <a id="links" href="https://icontribute.site/#/privacy"> (https://icontribute.site/#/privacy)</a>. 
           The terms used in this Privacy Policy have the same definitions as our Terms 
           and Conditions found below.
         </p>


### PR DESCRIPTION
What Changed:
- new CNAME was created as a result of updating the GitHub Pages Custom Domain Site link
- replaced all instances of `.community` with `.site` to account for new domain URL